### PR TITLE
contracts: Set evm version in foundry to paris

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -2,5 +2,6 @@
 src = "src"
 out = "out"
 libs = ["lib"]
+evm_version = "paris"
 
 # See more config options https://github.com/foundry-rs/foundry/blob/master/crates/config/README.md#all-options


### PR DESCRIPTION
Fixes https://github.com/oasisprotocol/demo-rofl-chatbot/issues/16