### PR TITLE
Fix typo in /sign-submit param name

### DIFF
--- a/oracle/src/RoflUtility.py
+++ b/oracle/src/RoflUtility.py
@@ -49,7 +49,7 @@ class RoflUtility:
                     "data": tx["data"].lstrip("0x"),
                 },
             },
-            "encrypted": False,
+            "encrypt": False,
         }
 
         path = '/rofl/v1/tx/sign-submit'


### PR DESCRIPTION
I don't know if this is actually behavior we want. But field name was wrong