### PR TITLE
compose.yaml: No need to expose 11434 externally in prod

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ podman-compose -f compose.localnet.yaml up
 ```
 
 Once all containers are up and running, open your web browser at
-`http://localnet:5173`.
+`http://localhost:5173`. You may also want to check out the Localnet block
+explorer at `http://localhost:8548` or connect to ollama instance directly at
+`http://localhost:11434`.
 
 ### Testnet deployment
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,8 +1,6 @@
 services:
   ollama:
     image: "docker.io/ollama/ollama"
-    ports:
-      - "11434:11434"
     volumes:
       - ollama-storage:/root/.ollama
     entrypoint: ["/usr/bin/bash", "-c", "/bin/ollama serve & sleep 5; ollama pull deepseek-r1:1.5b; wait"]


### PR DESCRIPTION
Inter-container communication works fine without exposing the ports externally.